### PR TITLE
Typo fix in readme, constructor() not component()

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ control whether to show the front or the back of the card.
 
 ```javascript
 class App extends React.Component {
-  component() {
+  constructor() {
     this.state = {
       isFlipped: false
     };

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ control whether to show the front or the back of the card.
 ```javascript
 class App extends React.Component {
   constructor() {
+    super();
+		
     this.state = {
       isFlipped: false
     };

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ control whether to show the front or the back of the card.
 class App extends React.Component {
   constructor() {
     super();
-		
     this.state = {
       isFlipped: false
     };


### PR DESCRIPTION
Pretty sure you mean `constructor()` and not `component()`, but please feel free to ignore if not.