### PR TITLE
Add whitelist of files to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "url": "https://github.com/AaronCCWong/react-card-flip/issues"
   },
   "homepage": "https://github.com/AaronCCWong/react-card-flip",
+  "files": [
+    "lib/**/*"
+  ],
   "dependencies": {
     "classnames": "^2.2.0",
     "prop-types": "^15.6.0"


### PR DESCRIPTION
See https://docs.npmjs.com/files/package.json#files for details, but this
makes it so config files and other unnecessary things aren't published to
npm.

One problem that it prevents is consumers from unintentionally reading the
config files and acting on them.  For instance, babel by default will try and
use the .babelrc file.