### PR TITLE
Fix yarn instructions on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ npm install --save react-card-flip
 To use react-card-flip, install it from NPM with yarn using the command:
 
 ```
-yarn add --dev react-card-flip
+yarn add react-card-flip
 ```
 
 You can also use the standalone build by including `lib/react-card-flip.js` in


### PR DESCRIPTION
Instructions to install with yarn was installing as dev dependency, removed `--dev`