### PR TITLE
Allow to specify the initial face via `props.isFlippable` if `props.infinite` is `true`

### DIFF
--- a/src/ReactCardFlip.tsx
+++ b/src/ReactCardFlip.tsx
@@ -19,7 +19,7 @@ const ReactCardFlip: React.FC<ReactFlipCardProps> = (props) => {
   } = props;
 
   const [isFlipped, setFlipped] = useState(props.isFlipped);
-  const [rotation, setRotation] = useState(0);
+  const [rotation, setRotation] = useState(props.isFlipped ? 180 : 0);
 
   useEffect(() => {
     if (props.isFlipped !== isFlipped) {


### PR DESCRIPTION
Hello @AaronCCWong, thank you for this library, very useful!! 

For a project I am working on, I needed to choose between showing the front or back of the card on mount, so I did:
```js
<CardFlip infinite={true} isFlippable{condition} ... > ... </CardFlip>
```

 But because I am setting `infinite` to true, `condition` didn't have an effect, and always, the front card was showing.