### PR TITLE
Fix 3D perspective effect

### DIFF
--- a/src/ReactCardFlip.tsx
+++ b/src/ReactCardFlip.tsx
@@ -87,11 +87,11 @@ const ReactCardFlip: React.FC<ReactFlipCardProps> = (props) => {
       ...back,
     },
     container: {
-      perspective: '1000px',
       zIndex: `${cardZIndex}`,
     },
     flipper: {
       height: '100%',
+      perspective: '1000px',
       position: 'relative',
       width: '100%',
     },


### PR DESCRIPTION
This fixes the 3D perspective effect by moving the perspective attribute from the container, where is currently does not do anything, to the flipper.

### Before

https://github.com/AaronCCWong/react-card-flip/assets/30873659/a208e6cd-a21d-47bd-a6f2-c178b5a89a17

### After

https://github.com/AaronCCWong/react-card-flip/assets/30873659/9055a64b-3077-4e44-8312-3f78f757fe68