### PR TITLE
Add option to disable 3D mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ and one for the back of the card.
 | flipSpeedFrontToBack | number | The speed of the flip animation when the card flips from front to back, the higher the number the slower the flip animation | 0.6          |
 | infinite             | bool   | False to rotate in opposite directions on both sides of the card, true to rotate in the same direction                      | false        |
 | flipDirection        | string | Direction of the card flip (options are: 'horizontal' or 'vertical' )                                                       | horizontal   |
+| mode3d               | bool   | False to disable perspective, making the flip not 3D.                                                                       | true         |
 
 ## Development (`src`, `lib` and the build process)
 

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -6,6 +6,7 @@ import FasterExample from './FasterExample';
 import RevolvingExample from './RevolvingExample';
 import SlowerExample from './SlowerExample';
 import VerticalExample from './VerticalExample';
+import Non3DExample from './Non3dExample';
 
 const App = () => {
   const styles = {
@@ -53,6 +54,12 @@ const App = () => {
         <h3>Vertical flip</h3>
 
         <VerticalExample styles={styles} />
+      </section>
+
+      <section className="example-section">
+        <h3>Non 3D flip</h3>
+
+        <Non3DExample styles={styles} />
       </section>
     </div>
   );

--- a/example/Non3DExample.tsx
+++ b/example/Non3DExample.tsx
@@ -1,0 +1,45 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+import ReactCardFlip from 'react-card-flip';
+
+class Non3DExample extends Component<any, any> {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isFlipped: false,
+    };
+    this.handleClick = this.handleClick.bind(this);
+  }
+
+  handleClick(event) {
+    event.preventDefault();
+    this.setState((prevState) => ({ isFlipped: !prevState.isFlipped }));
+  }
+
+  render() {
+    return (
+      <ReactCardFlip isFlipped={this.state.isFlipped} mode3d={false}>
+        <div style={this.props.styles.card}>
+          <img
+            style={this.props.styles.image}
+            src="//static.pexels.com/photos/59523/pexels-photo-59523.jpeg"
+          />
+
+          <button onClick={this.handleClick}>Flip Card</button>
+        </div>
+
+        <div style={this.props.styles.card}>
+          <img
+            style={this.props.styles.image}
+            src="//img.buzzfeed.com/buzzfeed-static/static/2014-04/enhanced/webdr06/4/16/enhanced-11136-1396643149-13.jpg?no-auto"
+          />
+
+          <button onClick={this.handleClick}>Flip Card</button>
+        </div>
+      </ReactCardFlip>
+    );
+  }
+}
+
+export default Non3DExample;

--- a/src/ReactCardFlip.tsx
+++ b/src/ReactCardFlip.tsx
@@ -5,10 +5,7 @@ import { ReactFlipCardProps } from '../types/index';
 
 const ReactCardFlip: React.FC<ReactFlipCardProps> = (props) => {
   const {
-    cardStyles: {
-      back,
-      front,
-    },
+    cardStyles: { back, front },
     cardZIndex,
     containerStyle,
     containerClassName,
@@ -17,6 +14,7 @@ const ReactCardFlip: React.FC<ReactFlipCardProps> = (props) => {
     flipSpeedBackToFront,
     infinite,
     isFlipped,
+    mode3d,
   } = {
     cardStyles: {
       back: {},
@@ -29,8 +27,9 @@ const ReactCardFlip: React.FC<ReactFlipCardProps> = (props) => {
     flipSpeedFrontToBack: 0.6,
     infinite: false,
     isFlipped: false,
-    ...props
-  }
+    mode3d: true,
+    ...props,
+  };
 
   const [isFlippedState, setFlipped] = useState(isFlipped);
   const [rotation, setRotation] = useState(0);
@@ -53,7 +52,7 @@ const ReactCardFlip: React.FC<ReactFlipCardProps> = (props) => {
   const getComponent = (key: 0 | 1) => {
     if (props.children.length !== 2) {
       throw new Error(
-        'Component ReactCardFlip requires 2 children to function',
+        'Component ReactCardFlip requires 2 children to function'
       );
     }
     return props.children[key];
@@ -61,16 +60,16 @@ const ReactCardFlip: React.FC<ReactFlipCardProps> = (props) => {
 
   const frontRotateY = `rotateY(${
     infinite ? rotation : isFlipped ? 180 : 0
-    }deg)`;
+  }deg)`;
   const backRotateY = `rotateY(${
     infinite ? rotation + 180 : isFlipped ? 0 : -180
-    }deg)`;
+  }deg)`;
   const frontRotateX = `rotateX(${
     infinite ? rotation : isFlipped ? 180 : 0
-    }deg)`;
+  }deg)`;
   const backRotateX = `rotateX(${
     infinite ? rotation + 180 : isFlipped ? 0 : -180
-    }deg)`;
+  }deg)`;
 
   const styles: any = {
     back: {
@@ -92,7 +91,7 @@ const ReactCardFlip: React.FC<ReactFlipCardProps> = (props) => {
     },
     flipper: {
       height: '100%',
-      perspective: '1000px',
+      perspective: mode3d ? '1000px' : 'none',
       position: 'relative',
       width: '100%',
     },

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -40,6 +40,11 @@ export interface ReactFlipCardProps {
    * @default 'horizontal'
    */
   flipDirection?: 'horizontal' | 'vertical';
+  /**
+   * If true, the card will flip in 3D mode. If false, the card will flip in 2D mode
+   * @default true
+   */
+  mode3d?: boolean;
   children: [React.ReactNode, React.ReactNode];
 }
 


### PR DESCRIPTION
### Description
This implements the `mode3d` prop which allow to control the perspective. It defaults to `true`.
When `true`, the perspective is set to `'1000px'`. When `false`, the perspective is set to `'none'`.

### Motivation
Well, the 3D flip is really cool. Nothing to say about that.
The point is I work on a project that uses the `react-card-flip` since last year and we never noticed it could make a 3D flip. 😅 
Since we upgraded to the [version 1.2.3](https://github.com/AaronCCWong/react-card-flip/releases/tag/v1.2.3), which fixed the 3D perspective effect, our UI broke because overflow is set to `hidden`. Before changing our UI I wondered what if it was possible to choose the flip mode between 3D or 2D. It could be useful not only for cases like mine but for preferences too.